### PR TITLE
Target .NET Standard

### DIFF
--- a/Beanstalk.Core.csproj
+++ b/Beanstalk.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netstandard1.3</TargetFramework>
         <Title>Beanstalk.Core</Title>
     </PropertyGroup>
 

--- a/BeanstalkConnection.cs
+++ b/BeanstalkConnection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Beanstalk.Core {
@@ -16,11 +17,14 @@ namespace Beanstalk.Core {
 
         private readonly ushort _port;
 
+        private readonly Encoding _encoding;
+
         private TcpClient _client;
 
-        public BeanstalkConnection(string host, ushort port) {
+        public BeanstalkConnection(string host, ushort port, Encoding encoding = null) {
             _host = host;
             _port = port;
+            _encoding = encoding ?? BeanstalkFactory.DefaultEncoding;
         }
 
         private async Task<NetworkStream> GetStream() {
@@ -33,98 +37,98 @@ namespace Beanstalk.Core {
         public void Dispose() { _client.Dispose(); }
 
         public async Task<ulong> Put(string data, TimeSpan delay, uint priority, TimeSpan ttr) {
-            return await new Command(await GetStream())
+            return await new Command(await GetStream(), _encoding)
                 .Put(priority, (uint) delay.TotalSeconds, (uint) ttr.TotalSeconds, data);
         }
 
         public async Task<ulong> Put(string data) {
-            return await new Command(await GetStream())
+            return await new Command(await GetStream(), _encoding)
                 .Put(DefaultPriority, (uint) DefaultDelay.TotalSeconds, (uint) DefaultTtr.TotalSeconds, data);
         }
 
         public async Task<ulong> Put(string data, uint priority) {
-            return await new Command(await GetStream())
+            return await new Command(await GetStream(), _encoding)
                 .Put(priority, (uint) DefaultDelay.TotalSeconds, (uint) DefaultTtr.TotalSeconds, data);
         }
 
         public async Task<ulong> Put(string data, TimeSpan delay) {
-            return await new Command(await GetStream())
+            return await new Command(await GetStream(), _encoding)
                 .Put(DefaultPriority, (uint) delay.TotalSeconds, (uint) DefaultTtr.TotalSeconds, data);
         }
 
-        public async Task Use(string tube) { await new Command(await GetStream()).Use(tube); }
+        public async Task Use(string tube) { await new Command(await GetStream(), _encoding).Use(tube); }
 
         public async Task<IJob> Reserve() {
-            return await new Command(await GetStream()).Reserve((uint) DefaultTtr.TotalSeconds);
+            return await new Command(await GetStream(), _encoding).Reserve((uint) DefaultTtr.TotalSeconds);
         }
 
         public async Task<IJob> Reserve(TimeSpan timeout) {
-            return await new Command(await GetStream()).Reserve((uint) timeout.TotalSeconds);
+            return await new Command(await GetStream(), _encoding).Reserve((uint) timeout.TotalSeconds);
         }
 
-        public async Task Delete(ulong id) { await new Command(await GetStream()).Delete(id); }
+        public async Task Delete(ulong id) { await new Command(await GetStream(), _encoding).Delete(id); }
 
         public async Task Release(ulong id) {
-            await new Command(await GetStream()).Release(id, DefaultPriority, (uint) DefaultDelay.TotalSeconds);
+            await new Command(await GetStream(), _encoding).Release(id, DefaultPriority, (uint) DefaultDelay.TotalSeconds);
         }
 
         public async Task Release(ulong id, uint priority) {
-            await new Command(await GetStream()).Release(id, priority, (uint) DefaultDelay.TotalSeconds);
+            await new Command(await GetStream(), _encoding).Release(id, priority, (uint) DefaultDelay.TotalSeconds);
         }
 
         public async Task Release(ulong id, TimeSpan delay) {
-            await new Command(await GetStream()).Release(id, DefaultPriority, (uint) delay.TotalSeconds);
+            await new Command(await GetStream(), _encoding).Release(id, DefaultPriority, (uint) delay.TotalSeconds);
         }
 
         public async Task Release(ulong id, uint priority, TimeSpan delay) {
-            await new Command(await GetStream()).Release(id, priority, (uint) delay.TotalSeconds);
+            await new Command(await GetStream(), _encoding).Release(id, priority, (uint) delay.TotalSeconds);
         }
 
-        public async Task Bury(ulong id) { await new Command(await GetStream()).Bury(id, DefaultPriority); }
+        public async Task Bury(ulong id) { await new Command(await GetStream(), _encoding).Bury(id, DefaultPriority); }
 
-        public async Task Bury(ulong id, uint priority) { await new Command(await GetStream()).Bury(id, priority); }
+        public async Task Bury(ulong id, uint priority) { await new Command(await GetStream(), _encoding).Bury(id, priority); }
 
-        public async Task Touch(ulong id) { await new Command(await GetStream()).Touch(id); }
+        public async Task Touch(ulong id) { await new Command(await GetStream(), _encoding).Touch(id); }
 
-        public async Task Watch(string tube) { await new Command(await GetStream()).Watch(tube); }
+        public async Task Watch(string tube) { await new Command(await GetStream(), _encoding).Watch(tube); }
 
-        public async Task Ignore(string tube) { await new Command(await GetStream()).Ignore(tube); }
+        public async Task Ignore(string tube) { await new Command(await GetStream(), _encoding).Ignore(tube); }
 
-        public async Task<IJob> Peek(ulong id) { return await new Command(await GetStream()).Peek(id); }
+        public async Task<IJob> Peek(ulong id) { return await new Command(await GetStream(), _encoding).Peek(id); }
 
-        public async Task<IJob> PeekReady() { return await new Command(await GetStream()).PeekReady(); }
+        public async Task<IJob> PeekReady() { return await new Command(await GetStream(), _encoding).PeekReady(); }
 
-        public async Task<IJob> PeekDelayed() { return await new Command(await GetStream()).PeekDelayed(); }
+        public async Task<IJob> PeekDelayed() { return await new Command(await GetStream(), _encoding).PeekDelayed(); }
 
-        public async Task<IJob> PeekBuried() { return await new Command(await GetStream()).PeekDelayed(); }
+        public async Task<IJob> PeekBuried() { return await new Command(await GetStream(), _encoding).PeekDelayed(); }
 
-        public async Task<uint> Kick(uint bound) { return await new Command(await GetStream()).Kick(bound); }
+        public async Task<uint> Kick(uint bound) { return await new Command(await GetStream(), _encoding).Kick(bound); }
 
-        public async Task KickJob(ulong id) { await new Command(await GetStream()).KickJob(id); }
+        public async Task KickJob(ulong id) { await new Command(await GetStream(), _encoding).KickJob(id); }
 
-        public async Task<string> StatsJob(ulong id) { return await new Command(await GetStream()).StatsJob(id); }
+        public async Task<string> StatsJob(ulong id) { return await new Command(await GetStream(), _encoding).StatsJob(id); }
 
         public async Task<string> StatsTube(string tube) {
-            return await new Command(await GetStream()).StatsTube(tube);
+            return await new Command(await GetStream(), _encoding).StatsTube(tube);
         }
 
-        public async Task<string> Stats() { return await new Command(await GetStream()).Stats(); }
+        public async Task<string> Stats() { return await new Command(await GetStream(), _encoding).Stats(); }
 
-        public async Task<string> ListTubes() { return await new Command(await GetStream()).ListTubes(); }
+        public async Task<string> ListTubes() { return await new Command(await GetStream(), _encoding).ListTubes(); }
 
-        public async Task<string> ListTubeUsed() { return await new Command(await GetStream()).ListTubeUsed(); }
+        public async Task<string> ListTubeUsed() { return await new Command(await GetStream(), _encoding).ListTubeUsed(); }
 
-        public async Task<string> ListTubesWatched() { return await new Command(await GetStream()).ListTubesWatched(); }
+        public async Task<string> ListTubesWatched() { return await new Command(await GetStream(), _encoding).ListTubesWatched(); }
 
         public async Task Pause(string tube) {
-            await new Command(await GetStream()).PauseTube(tube, (uint) DefaultDelay.TotalSeconds);
+            await new Command(await GetStream(), _encoding).PauseTube(tube, (uint) DefaultDelay.TotalSeconds);
         }
 
         public async Task Pause(string tube, TimeSpan delay) {
-            await new Command(await GetStream()).PauseTube(tube, (uint) delay.TotalSeconds);
+            await new Command(await GetStream(), _encoding).PauseTube(tube, (uint) delay.TotalSeconds);
         }
 
-        public async Task Quit() { await new Command(await GetStream()).Quit(); }
+        public async Task Quit() { await new Command(await GetStream(), _encoding).Quit(); }
 
     }
 

--- a/BeanstalkFactory.cs
+++ b/BeanstalkFactory.cs
@@ -1,18 +1,24 @@
+using System.Text;
+
 namespace Beanstalk.Core {
 
     public class BeanstalkFactory {
+
+        internal static Encoding DefaultEncoding = Encoding.ASCII;
 
         private readonly string _host;
 
         private readonly ushort _port;
 
-        public BeanstalkFactory(string host, ushort port) {
+        private readonly Encoding _encoding;
+
+        public BeanstalkFactory(string host, ushort port, Encoding encoding = null) {
             _host = host;
             _port = port;
+            _encoding = encoding ?? DefaultEncoding;
         }
 
-        public BeanstalkConnection GetConnection() { return new BeanstalkConnection(_host, _port); }
-
+        public BeanstalkConnection GetConnection() => new BeanstalkConnection(_host, _port, _encoding);
     }
 
 }

--- a/Command.cs
+++ b/Command.cs
@@ -10,13 +10,14 @@ namespace Beanstalk.Core {
     public class Command : IConnection {
 
         private readonly NetworkStream _stream;
-
+        private readonly Encoding _encoding;
         private byte[] _command;
 
         private readonly Dictionary<string, Action<string>> _checkers = new Dictionary<string, Action<string>>();
 
-        public Command(NetworkStream stream) {
+        public Command(NetworkStream stream, Encoding encoding) {
             _stream = stream;
+            _encoding = encoding;
             _checkers.Add("INTERNAL_ERROR", resp => throw new BeanstalkException(resp));
             _checkers.Add("OUT_OF_MEMORY", resp => throw new BeanstalkException(resp));
             _checkers.Add("BAD_FORMAT", resp => throw new BeanstalkException(resp));
@@ -24,18 +25,18 @@ namespace Beanstalk.Core {
         }
 
         private async Task<string[]> Expect(string code) {
-            await _stream.WriteAsync(_command);
-            var response = _stream.ReadResponse().Trim();
-            var split = response.Split(" ");
+            await _stream.WriteAsync(_command, 0, _command.Length);
+            var response = _stream.ReadResponse(_encoding);
+            var split = response.Split(' ');
             _checkers.FirstOrDefault(item => item.Key == split[0]).Value?.Invoke(response);
             if (code != split[0]) throw new BeanstalkException($"FATAL_ERROR: expect {code}, {split[0]} gave.");
             return split;
         }
 
         public async Task<ulong> Put(uint priority, uint delay, uint ttr, string data) {
-            var len = Encoding.Default.GetByteCount(data);
+            var len = _encoding.GetByteCount(data);
             Console.WriteLine("Data {0} Length: {1}", data, len);
-            _command = Encoding.Default.GetBytes($"put {priority} {delay} {ttr} {len}\r\n{data}\r\n");
+            _command = _encoding.GetBytes($"put {priority} {delay} {ttr} {len}\r\n{data}\r\n");
             _checkers.Add("BURIED", resp => throw new BeanstalkException(resp));
             _checkers.Add("EXPECTED_CRLF", resp => throw new BeanstalkException(resp));
             _checkers.Add("JOB_TOO_BIG", resp => throw new BeanstalkException(resp));
@@ -45,132 +46,132 @@ namespace Beanstalk.Core {
         }
 
         public async Task Use(string tube) {
-            _command = Encoding.Default.GetBytes($"use {tube}\r\n");
+            _command = _encoding.GetBytes($"use {tube}\r\n");
             await Expect("USING");
         }
 
         public async Task<IJob> Reserve(uint timeout) {
-            _command = Encoding.Default.GetBytes($"reserve-with-timeout {timeout}\r\n");
+            _command = _encoding.GetBytes($"reserve-with-timeout {timeout}\r\n");
             _checkers.Add("DEADLINE_SOON", resp => throw new BeanstalkException(resp));
             _checkers.Add("TIMED_OUT", resp => throw new BeanstalkException(resp));
             return await ParseJob(await Expect("RESERVED"));
         }
 
         public async Task Delete(ulong id) {
-            _command = Encoding.Default.GetBytes($"delete {id}\r\n");
+            _command = _encoding.GetBytes($"delete {id}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             await Expect("DELETED");
         }
 
         public async Task Release(ulong id, uint priority, uint delay) {
-            _command = Encoding.Default.GetBytes($"release {id} {priority} {delay}\r\n");
+            _command = _encoding.GetBytes($"release {id} {priority} {delay}\r\n");
             _checkers.Add("BURIED", resp => throw new BeanstalkException(resp));
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             await Expect("RELEASED");
         }
 
         public async Task Bury(ulong id, uint priority) {
-            _command = Encoding.Default.GetBytes($"bury {id} {priority}\r\n");
+            _command = _encoding.GetBytes($"bury {id} {priority}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             await Expect("BURIED");
         }
 
         public async Task Touch(ulong id) {
-            _command = Encoding.Default.GetBytes($"touch {id}\r\n");
+            _command = _encoding.GetBytes($"touch {id}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             await Expect("TOUCHED");
         }
 
         public async Task<uint> Watch(string tube) {
-            _command = Encoding.Default.GetBytes($"watch {tube}\r\n");
+            _command = _encoding.GetBytes($"watch {tube}\r\n");
             var response = await Expect("WATCHING");
             return uint.Parse(response[1]);
         }
 
         public async Task<uint> Ignore(string tube) {
-            _command = Encoding.Default.GetBytes($"ignore {tube}\r\n");
+            _command = _encoding.GetBytes($"ignore {tube}\r\n");
             _checkers.Add("NOT_IGNORED", resp => throw new BeanstalkException(resp));
             var response = await Expect("WATCHING");
             return uint.Parse(response[1]);
         }
 
         public async Task<IJob> Peek(ulong id) {
-            _command = Encoding.Default.GetBytes($"peek {id}\r\n");
+            _command = _encoding.GetBytes($"peek {id}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             return await ParseJob(await Expect("FOUND"));
         }
 
         public async Task<IJob> PeekReady() {
-            _command = Encoding.Default.GetBytes("peek-ready\r\n");
+            _command = _encoding.GetBytes("peek-ready\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             return await ParseJob(await Expect("FOUND"));
         }
 
         public async Task<IJob> PeekDelayed() {
-            _command = Encoding.Default.GetBytes("peek-delayed\r\n");
+            _command = _encoding.GetBytes("peek-delayed\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             return await ParseJob(await Expect("FOUND"));
         }
 
         public async Task<IJob> PeekBuried() {
-            _command = Encoding.Default.GetBytes("peek-buried\r\n");
+            _command = _encoding.GetBytes("peek-buried\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             return await ParseJob(await Expect("FOUND"));
         }
 
         public async Task<uint> Kick(uint bound) {
-            _command = Encoding.Default.GetBytes($"kick {bound}\r\n");
+            _command = _encoding.GetBytes($"kick {bound}\r\n");
             var response = await Expect("KICKED");
             return uint.Parse(response[1]);
         }
 
         public async Task KickJob(ulong id) {
-            _command = Encoding.Default.GetBytes($"kick-job {id}\r\n");
+            _command = _encoding.GetBytes($"kick-job {id}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             await Expect("KICKED");
         }
 
         public async Task<string> StatsJob(ulong id) {
-            _command = Encoding.Default.GetBytes($"stats-job {id}\r\n");
+            _command = _encoding.GetBytes($"stats-job {id}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             return await ParseOk(await Expect("OK"));
         }
 
         public async Task<string> StatsTube(string tube) {
-            _command = Encoding.Default.GetBytes($"stats-tube {tube}\r\n");
+            _command = _encoding.GetBytes($"stats-tube {tube}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             return await ParseOk(await Expect("OK"));
         }
 
         public async Task<string> Stats() {
-            _command = Encoding.Default.GetBytes("stats\r\n");
+            _command = _encoding.GetBytes("stats\r\n");
             return await ParseOk(await Expect("OK"));
         }
 
         public async Task<string> ListTubes() {
-            _command = Encoding.Default.GetBytes("list-tubes\r\n");
+            _command = _encoding.GetBytes("list-tubes\r\n");
             return await ParseOk(await Expect("OK"));
         }
 
         public async Task<string> ListTubeUsed() {
-            _command = Encoding.Default.GetBytes("list-tube-used\r\n");
+            _command = _encoding.GetBytes("list-tube-used\r\n");
             var response = await Expect("USING");
             return response[1];
         }
 
         public async Task<string> ListTubesWatched() {
-            _command = Encoding.Default.GetBytes("list-tubes-watched\r\n");
+            _command = _encoding.GetBytes("list-tubes-watched\r\n");
             return await ParseOk(await Expect("OK"));
         }
 
         public async Task PauseTube(string tube, uint delay) {
-            _command = Encoding.Default.GetBytes($"pause-tube {tube} {delay}\r\n");
+            _command = _encoding.GetBytes($"pause-tube {tube} {delay}\r\n");
             _checkers.Add("NOT_FOUND", resp => throw new BeanstalkException(resp));
             await Expect("PAUSED");
         }
 
         public async Task Quit() {
-            _command = Encoding.Default.GetBytes("quit\r\n");
+            _command = _encoding.GetBytes("quit\r\n");
             await Expect(string.Empty);
         }
 
@@ -180,7 +181,7 @@ namespace Beanstalk.Core {
             await _stream.ReadAsync(bytes, 0, len);
             return new Job {
                 Id = ulong.Parse(response[1]),
-                Data = Encoding.Default.GetString(bytes)
+                Data = _encoding.GetString(bytes)
             };
         }
 
@@ -188,7 +189,7 @@ namespace Beanstalk.Core {
             var len = int.Parse(response[1]) + 2;
             var bytes = new byte[len];
             await _stream.ReadAsync(bytes, 0, len);
-            return Encoding.Default.GetString(bytes);
+            return _encoding.GetString(bytes);
         }
 
     }

--- a/NetworkStreamExtension.cs
+++ b/NetworkStreamExtension.cs
@@ -7,7 +7,7 @@ namespace Beanstalk.Core {
 
     public static class NetworkStreamExtension {
 
-        public static string ReadResponse(this NetworkStream stream) {
+        public static string ReadResponse(this NetworkStream stream, Encoding encoding) {
             using (var ms = new MemoryStream()) {
                 var last = -1;
                 while (true) {
@@ -17,7 +17,7 @@ namespace Beanstalk.Core {
                     if (last == 13 && ret == 10) break;
                     last = ret;
                 }
-                return Encoding.Default.GetString(ms.ToArray()).Trim();
+                return encoding.GetString(ms.ToArray()).Trim();
             }
         }
 


### PR DESCRIPTION
Since .NET Core 2.2 has reached End of Life might I suggest targeting .NET Standard instead?  

IMO there is only one thing to consider:  
The default encoding is no longer save to use when targeting .NET Standard. It might be a 16 bit Unicode variant which is not supported by the [beanstalkd protocol](https://github.com/beanstalkd/beanstalkd/blob/v1.11/doc/protocol.txt).  
Only ASCII encoding is supported, so I made it the default.  
But you can probably also use UTF-8, so I left it configurable.

One could argue that UTF-8 Would be the better default, but I'm not sure about that.
One could also argue that only binary data should be supported. But that would break the backward compatibility. And I did not want to go that far :)