### PR TITLE
Fix potential NullReferenceException in BeanstalkConnection.Dispose

### DIFF
--- a/BeanstalkConnection.cs
+++ b/BeanstalkConnection.cs
@@ -30,7 +30,7 @@ namespace Beanstalk.Core {
             return _client.GetStream();
         }
 
-        public void Dispose() { _client.Dispose(); }
+        public void Dispose() { _client?.Dispose(); }
 
         public async Task<ulong> Put(string data, TimeSpan delay, uint priority, TimeSpan ttr) {
             return await new Command(await GetStream())


### PR DESCRIPTION
If a `BeanstalkConnection` is created and disposed without invoking any Beanstalk commands, the `_client` field remains null, causing a `NullReferenceException` in `Dispose`. Adding a null-conditional operator handles this scenario.

Simple repro:

```
Console.WriteLine("before");
var client = new Beanstalk.Core.BeanstalkConnection("127.0.0.1", 11300);
client.Dispose();
Console.WriteLine("after");
```