### PR TITLE
Fix BeanstalkConnection.PeekBuried to use correct command

### DIFF
--- a/BeanstalkConnection.cs
+++ b/BeanstalkConnection.cs
@@ -96,7 +96,7 @@ namespace Beanstalk.Core {
 
         public async Task<IJob> PeekDelayed() { return await new Command(await GetStream()).PeekDelayed(); }
 
-        public async Task<IJob> PeekBuried() { return await new Command(await GetStream()).PeekDelayed(); }
+        public async Task<IJob> PeekBuried() { return await new Command(await GetStream()).PeekBuried(); }
 
         public async Task<uint> Kick(uint bound) { return await new Command(await GetStream()).Kick(bound); }
 


### PR DESCRIPTION
`BeanstalkConnection.PeekBuried` was calling into `PeekDelayed` before, probably a copy-paste error. Now it calls the correct underlying command.